### PR TITLE
Fix UTF-8 script lint errors on Windows

### DIFF
--- a/linter.py
+++ b/linter.py
@@ -18,7 +18,7 @@ class Ruby(RubyLinter):
     """Provides an interface to ruby -wc."""
 
     syntax = ('ruby', 'ruby on rails', 'rspec')
-    cmd = 'ruby -wc'
+    cmd = 'ruby -wc -Ku'
     regex = (
         r'^.+?:(?P<line>\d+): (?:(?P<error>.*?error)|(?P<warning>warning))[,:] (?P<message>[^\r\n]+)\r?\n'
         r'(?:^[^\r\n]+\r?\n^(?P<col>.*?)\^)?'


### PR DESCRIPTION
I have an issue like #6 on Windows.
This is a patch.

Script encoding from STDIN is determined by locale.
LANG environment variable doesn't change locale on Windows Ruby.
Instead setting `-Ku` options makes script encoding UTF-8.
